### PR TITLE
feat: Drama Detail Page 정렬 추가 및 스타일 수정, redirection 추가

### DIFF
--- a/src/dramas/management/commands/setup_data.py
+++ b/src/dramas/management/commands/setup_data.py
@@ -9,16 +9,16 @@ class Command(BaseCommand):
 
         try:
             # 1. 드라마 기본 정보 크롤링
-            self.stdout.write(self.style.NOTICE("\n[1/4] 드라마 기본 정보 크롤링을 시작합니다..."))
-            call_command('crawl_dramas')
-            call_command('crawl_dramas_desc')
-            call_command('crawl_dramas_img')
-            self.stdout.write(self.style.SUCCESS("[1/4] 드라마 기본 정보 크롤링 완료!"))
+            # self.stdout.write(self.style.NOTICE("\n[1/4] 드라마 기본 정보 크롤링을 시작합니다..."))
+            # call_command('crawl_dramas')
+            # call_command('crawl_dramas_desc')
+            # call_command('crawl_dramas_img')
+            # self.stdout.write(self.style.SUCCESS("[1/4] 드라마 기본 정보 크롤링 완료!"))
 
-            # 2. 드라마 회차 정보 크롤링
-            self.stdout.write(self.style.NOTICE("\n[2/4] 드라마 회차별 상세 정보 크롤링을 시작합니다..."))
-            call_command('crawler_episodes')
-            self.stdout.write(self.style.SUCCESS("[2/4] 드라마 회차별 상세 정보 크롤링 완료!"))
+            # # 2. 드라마 회차 정보 크롤링
+            # self.stdout.write(self.style.NOTICE("\n[2/4] 드라마 회차별 상세 정보 크롤링을 시작합니다..."))
+            # call_command('crawler_episodes')
+            # self.stdout.write(self.style.SUCCESS("[2/4] 드라마 회차별 상세 정보 크롤링 완료!"))
 
             # 4. 장르 크롤링
             self.stdout.write(self.style.NOTICE("\n[3/4] 드라마 장르 크롤링을 시작합니다..."))
@@ -26,10 +26,10 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS("[3/4] 드라마 장르 크롤링 완료!"))
 
 
-            # 5. 뉴스 정보 크롤링
-            self.stdout.write(self.style.NOTICE("\n[4/4] 드라마 관련 뉴스 정보 크롤링을 시작합니다..."))
-            call_command('crawl_news')
-            self.stdout.write(self.style.SUCCESS("[4/4] 드라마 관련 뉴스 정보 크롤링 완료!"))
+            # # 5. 뉴스 정보 크롤링
+            # self.stdout.write(self.style.NOTICE("\n[4/4] 드라마 관련 뉴스 정보 크롤링을 시작합니다..."))
+            # call_command('crawl_news')
+            # self.stdout.write(self.style.SUCCESS("[4/4] 드라마 관련 뉴스 정보 크롤링 완료!"))
 
         except Exception as e:
             self.stdout.write(self.style.ERROR(f"\n초기 데이터 설정 중 오류가 발생했습니다: {e}"))

--- a/src/dramas/static/dramas/drama_detail.css
+++ b/src/dramas/static/dramas/drama_detail.css
@@ -51,10 +51,6 @@ h1 {
   flex: 1 1 auto;
 }
 
-/* 오른쪽 이미지는 고정폭(원하면 값 조절) */
-.drama-info-image {
-  flex: 0 0 400px;
-}
 
 .drama-info-image img {
   width: 100%;

--- a/src/dramas/tests/test_drama_episodes.py
+++ b/src/dramas/tests/test_drama_episodes.py
@@ -1,0 +1,76 @@
+from django.test.testcases import TestCase
+from django.urls.base import reverse
+
+from dramas.models import EpisodeInfo, Drama
+
+
+class DramaEpisodesTest(TestCase):
+    def setUp(self):
+        self.drama1 = Drama(
+            title="태양의 후예",
+            start_date="2016-02-24",
+            end_date="2016-04-14",
+        )
+        self.drama1.save()
+        self.drama_ep1 = EpisodeInfo(
+            drama=self.drama1,
+            episode_no=1,
+            date='2016-02-24',
+            rating="1.3",
+            query="태양의 후예 1화",
+            source_url="example.com"
+        )
+        self.drama_ep2 = EpisodeInfo(
+            drama=self.drama1,
+            episode_no=2,
+            date='2016-02-25',
+            rating="2.3",
+            query="태양의 후예 2화",
+            source_url="example.com"
+        )
+        self.drama_ep3 = EpisodeInfo(
+            drama=self.drama1,
+            episode_no=3,
+            date='2016-03-02',
+            rating="3.3",
+            query="태양의 후예 3화",
+            source_url="example.com"
+        )
+        self.drama_ep3.save()
+        self.drama_ep2.save()
+        self.drama_ep1.save()
+
+        self.assertEqual(Drama.objects.count(), 1)
+
+    def test_episode_ordering(self):
+        # given
+        url = reverse("drama-detail", args=[self.drama1.id])
+
+        # when
+        # news_count 기준 정렬
+        response_by_news = list(
+            self.client.get(url, data={'order_by': '-news_count'}).context[
+                'drama'].episodes.all())
+
+        # rating 기준 정렬
+        response_by_rating = list(
+            self.client.get(url, data={'order_by': '-rating'}).context[
+                'drama'].episodes.all())
+
+        # episode_no 기준 정렬
+        response_by_no = list(
+            self.client.get(url, data={'order_by': 'episode_no'}).context[
+                'drama'].episodes.all())
+
+        # then
+        for i in range(len(response_by_news) - 1):
+            # 뉴스 많은 순 내림차순
+            self.assertGreaterEqual(response_by_news[i].news_count,
+                                    response_by_news[i + 1].news_count)
+            # 시청률 내림차순
+            self.assertGreaterEqual(float(response_by_rating[i].rating or 0),
+                                    float(
+                                        response_by_rating[i + 1].rating or 0))
+            # 회차 오름차순
+            self.assertLessEqual(response_by_no[i].episode_no,
+                                 response_by_no[i + 1].episode_no)

--- a/src/dramas/views.py
+++ b/src/dramas/views.py
@@ -196,7 +196,25 @@ def dashboard_metrics(request):
 
 
 def drama_detail_view(request, pk):
+    order_by = request.GET.get('order_by', 'episode_no')
+
+    if order_by not in ['episode_no', '-episode_no', 'news_count',
+                        '-news_count',
+                        'rating', '-rating']:
+        order_by = 'episode_no'  # fallback
+
+    episodes_qs = (
+        EpisodeInfo.objects
+        .annotate(news_count=Count('drama_news'))
+        .order_by(order_by)
+    )
     drama = Drama.objects.prefetch_related(
-        Prefetch('episodes', queryset=EpisodeInfo.objects.order_by('episode_no'))
+        Prefetch('episodes', queryset=episodes_qs)
     ).get(pk=pk)
-    return render(request, "dramas/drama_detail.html", {"drama": drama})
+
+    return render(request,
+                  template_name="dramas/drama_detail.html",
+                  context={
+                      "drama": drama,
+                      "current_order": order_by
+                  })

--- a/src/templates/dramas/drama_detail.html
+++ b/src/templates/dramas/drama_detail.html
@@ -5,141 +5,245 @@
   <meta charset="UTF-8">
   <title>{{ drama.title }}</title>
   <link rel="stylesheet" href="{% static 'dramas/drama_detail.css' %}">
-  <!-- Chart.js CDN -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    .sort-links {
+      margin-bottom: 20px;
+    }
 
-  
+    .sort-btn {
+      display: inline-block;
+      padding: 5px 12px;
+      margin-right: 10px;
+      text-decoration: none;
+      color: #333;
+      background-color: #f0f0f0;
+      border-radius: 5px;
+      transition: background-color 0.2s;
+    }
+
+    .sort-btn:hover {
+      background-color: #ddd;
+    }
+
+    .sort-btn.active {
+      background-color: #007bff;
+      color: white;
+      font-weight: bold;
+      border: 1px solid #0056b3;
+    }
+
+    .episode-item {
+      margin-bottom: 20px;
+      padding: 10px;
+      border-radius: 5px;
+    }
+
+    .highlight {
+      background-color: rgba(255, 255, 0, 0.3);
+      transition: background-color 0.5s;
+    }
+  </style>
 </head>
 <body>
-  <div class="container">
-    <h1>{{ drama.title }}</h1>
+<div class="container" style="width: 100%;">
+  <h1><a href="/dramas">드라마</a> / {{ drama.title }}</h1>
 
-    <div class="drama-info-wrapper">
-      <div class="drama-info-text">
-        <!-- 드라마 기본 정보들 -->
-        <p>
-          <strong>방송사:</strong> {{ drama.channel }}
-        </p>
-        <p>
-          <strong>방영 기간:</strong> {{ drama.start_date }} ~ {{ drama.end_date }}
-        </p>
-        <p class="genre">
-          <strong>장르:</strong>
-            {% if drama.genres.all %}
-                {% for g in drama.genres.all %}
-                    {{ g.name }}{% if not forloop.last %}, {% endif %}
-                {% endfor %}
-            {% else %}
-                정보 없음
-            {% endif %}
-        </p>
+  <!-- 드라마 기본 정보 -->
+  <div
+      style=" display: flex; flex-flow: row nowrap; justify-content: space-between; align-items: flex-start;">
+    <div
+        style="display: flex; flex-flow: column nowrap; justify-content: flex-start; align-items: center;">
 
-        {% if drama.description %}
-          <p>{{ drama.description }}</p>
-        {% endif %}
-        <!-- 더 넣을 정보 있다면 여기에 추가 -->
-      </div>
-    
+      <div>
       {% if drama.img_url %}
-        <div class="drama-info-image">
-          <img src="{{ drama.img_url }}" alt="{{ drama.title }}">
-        </div>
+        <img src="{{ drama.img_url }}" alt="{{ drama.title }}"
+             style="max-width: 300px; height: auto;">
       {% else %}
-        <div class="drama-info-image">
-          <img src="{% static 'dramas/images/default_thumb.jpg' %}" alt="{{ drama.title }}">
-        </div>
+        <img src="{% static 'dramas/images/default_thumb.jpg' %}" alt="{{ drama.title }}">
       {% endif %}
     </div>
+      <div
+          style="display: flex; flex-flow: column nowrap; justify-content: space-between; align-items: flex-start;">
+        <div>
 
-    <!-- {% if drama.img_url %}
-      <img src="{{ drama.img_url }}" alt="{{ drama.title }}">
-    {% else %}
-      <img src="{% static 'dramas/images/default_thumb.jpg' %}" alt="No Image">
-    {% endif %}
+          <p><strong>방송사:</strong> {{ drama.channel }}</p>
+          <p><strong>방영 기간</strong></p>
+          <p>{{ drama.start_date }} ~ {{ drama.end_date }}</p>
+        </div>
+        <p class="genre">
+          <strong>장르:</strong>
+        <div style="display: flex; flex-flow: row wrap">
 
-    {% if drama.description %}
-      <p>{{ drama.description }}</p>
-    {% endif %} -->
+          {% if drama.genres.all %}
+            {% for g in drama.genres.all %}
+              <button
+                  onClick="window.location='{% url 'drama-list' %}?genre={{ g.name }}';"
+                  style="margin: 2px; padding: 5px 10px; border: none; background-color: #e0e0e0; border-radius: 5px; cursor: pointer;">
 
-    <hr>
 
-    <!-- 그래프 그릴 영역 -->
-    <h2>시청률 그래프</h2>
-    <canvas id="ratingChart" width="600" height="300"></canvas>
-    
-    <hr>
+                {{ g.name }}{% if not forloop.last %}{% endif %}
+              </button>
 
-    <!-- 에피소드 목록 -->
-    <h2>에피소드 목록</h2>
-    {% if drama.episodes %}
-      <ul class="episode-list">
-        {% for ep in drama.episodes.all %}
-          <li class="episode-item">
-            <h3>{{ ep.episode_no }}회 ({{ ep.date }})</h3>
-            <p><strong>시청률:</strong> {{ ep.rating }}%</p>
-            <p>{{ ep.synopsis }}</p>
-            <p>
-              🔗 <a href="{{ ep.source_url }}" target="_blank">네이버 검색 결과 보기</a>
-            </p>
+            {% endfor %}
+          {% else %} 정보 없음 {% endif %}
+        </div>
+        </p>
 
-            <!-- 더보기: 뉴스 목록 -->
-            <details class="news-block">
-              <summary>
-                더보기 (뉴스 {{ ep.drama_news.count }}건)
-              </summary>
+      </div>
+    </div>
+    <div
+        style=" display: flex ; flex-flow: column nowrap; justify-content: flex-start; align-items: flex-start; flex-grow: 1">
+      <h2>시청률 / 뉴스 수 그래프</h2>
+      <canvas id="ratingChart" width="520px" height="300px" style="flex: 1 1 auto"></canvas>
+    </div>
+  </div>
+  {% if drama.description %}<p>{{ drama.description }}</p>{% endif %}
+  <hr>
+  <div class="sort-links">
+    <a href="?order_by=episode_no"
+       class="sort-btn {% if current_order == 'episode_no' %}active{% endif %}">회차 오름차순</a>
+    <a href="?order_by=-rating"
+       class="sort-btn {% if current_order == '-rating' %}active{% endif %}">시청률 높은 순</a>
+    <a href="?order_by=-news_count"
+       class="sort-btn {% if current_order == '-news_count' %}active{% endif %}">뉴스 많은 순</a>
+  </div>
+  <!-- 에피소드 목록 -->
+  <h2>에피소드 목록</h2>
+  {% if drama.episodes %}
+    <ul class="episode-list">
+      {% for ep in drama.episodes.all %}
+        <li class="episode-item" id="episode-{{ ep.episode_no }}">
+          <h3>{{ ep.episode_no }}회 ({{ ep.date }})</h3>
+          <p><strong>시청률:</strong> {{ ep.rating }}%</p>
+          <p>{{ ep.synopsis }}</p>
+          <p>🔗 <a href="{{ ep.source_url }}" target="_blank">네이버 검색 결과 보기</a></p>
+
+          <details class="news-block">
+            <summary>더보기 (뉴스 {{ ep.drama_news.count }}건)</summary>
             <ul class="news-list">
               {% for n in ep.drama_news.all %}
                 <li class="news-item">
                   <a href="{{ n.link }}" target="_blank">{{ n.title }}</a><br>
-                  <strong>- ({{ n.press }}) {{ n.date }}</strong><br>
-                  <!-- {% if n.content %}<p>{{ n.content }}</p>{% endif %} -->
+                  <strong>- ({{ n.press }}) {{ n.date }}</strong>
                 </li>
               {% empty %}
                 <li>등록된 뉴스가 없습니다.</li>
-            {% endfor %}
+              {% endfor %}
             </ul>
-            </details>
+          </details>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>등록된 에피소드가 없습니다.</p>
+  {% endif %}
+</div>
 
-          </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p>등록된 에피소드가 없습니다.</p>
-    {% endif %}
-  </div>
+<script>
+  // X축: 항상 회차 순
+  const episodeNos = [{% for ep in drama.episodes.all|dictsort:"episode_no" %}{{ ep.episode_no }},
+    {% endfor %}];
+  const airingDates = [{% for ep in drama.episodes.all|dictsort:"episode_no" %}'{{ ep.date }}',
+  {% endfor %}];
 
-  <!-- 그래프 스크립트 (body 맨 아래에 두는 게 일반적) -->
-  <script>
-    // 장고 템플릿 데이터 → 자바스크립트 배열로 변환
-    const labels = [{% for ep in drama.episodes.all %} {{ ep.episode_no }}, {% endfor %}];
-    const data = [{% for ep in drama.episodes.all %} {{ ep.rating }}, {% endfor %}];
-    
-    // const episodes = JSON.parse(document.getElementById("episodes-data").textContent);
+  // 정렬 기준에 따라 Y축 값 배열 생성
+  const ratingsMap = {};
+  const newsMap = {};
+  {% for ep in drama.episodes.all %}
+    ratingsMap[{{ ep.episode_no }}] = {{ ep.rating|default:0 }};
+    newsMap[{{ ep.episode_no }}] = {{ ep.news_count|default:0 }};
+  {% endfor %}
 
-    // const labels = episodes.map(ep => ep.episode_no);
-    // const data = episodes.map(ep => ep.rating);
+  // Y축 데이터: X축 회차 순서에 맞춰서 매핑
+  const ratings = episodeNos.map(no => ratingsMap[no]);
+  const newsCounts = episodeNos.map(no => newsMap[no]);
 
-    const ctx = document.getElementById('ratingChart').getContext('2d');
-    const ratingChart = new Chart(ctx, {
-      type: 'line',
-      data: {
-        labels: labels, // x축 (회차 번호)
-        datasets: [{
+  const ctx = document.getElementById('ratingChart').getContext('2d');
+
+  const ratingChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: episodeNos.map(no => no + '회'),
+      datasets: [
+        {
           label: '시청률 (%)',
-          data: data,    // y축 (시청률)
+          data: ratings,
           borderColor: 'blue',
           backgroundColor: 'rgba(0, 0, 255, 0.2)',
           fill: true,
-          tension: 0.3
-        }]
+          tension: 0.3,
+          pointRadius: 5,
+          pointHoverRadius: 7,
+          yAxisID: 'yRatings'
+        },
+        {
+          label: '뉴스 수',
+          data: newsCounts,
+          borderColor: 'orange',
+          backgroundColor: 'rgba(255, 165, 0, 0.2)',
+          fill: false,
+          tension: 0.3,
+          pointRadius: 5,
+          pointHoverRadius: 7,
+          yAxisID: 'yNews'
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: function (context) {
+              const index = context.dataIndex;
+              const epNo = episodeNos[index];
+              const date = airingDates[index];
+              const val = context.dataset.data[index];
+              if (context.dataset.label === '시청률 (%)') {
+                return `시청률: ${val}% (${epNo}회, ${date})`;
+              } else {
+                return `뉴스 수: ${val} (${epNo}회, ${date})`;
+              }
+            }
+          }
+        }
       },
-      options: {
-        responsive: true,
-        scales: {
-          y: { beginAtZero: true }
+      interaction: {mode: 'index', intersect: false},
+      onClick: (evt, elements) => {
+        if (elements.length > 0) {
+          const index = elements[0].index;
+          const epNo = episodeNos[index];
+          const el = document.getElementById('episode-' + epNo);
+          if (el) {
+            el.scrollIntoView({behavior: 'smooth'});
+            el.classList.add('highlight');
+            setTimeout(() => {
+              el.classList.remove('highlight');
+            }, 1000);
+          }
+        }
+      },
+      scales: {
+        yRatings: {
+          type: 'linear',
+          position: 'left',
+          beginAtZero: true,
+          title: {display: true, text: '시청률 (%)'}
+        },
+        yNews: {
+          type: 'linear',
+          position: 'right',
+          beginAtZero: true,
+          grid: {drawOnChartArea: false},
+          title: {display: true, text: '뉴스 수'}
+        },
+        x: {
+          title: {display: true, text: '회차'}
         }
       }
-    });
-  </script>
+    }
+  });
+</script>
 </body>
 </html>

--- a/src/templates/dramas/drama_list.html
+++ b/src/templates/dramas/drama_list.html
@@ -50,10 +50,14 @@
             <ul class="ranking-list">
                 {% if top_10_dramas %}
                     {% for drama in top_10_dramas %}
-                        <li class="ranking-item">
+                      <li class="ranking-item">
                             <span class="rank-number">{{ forloop.counter }}</span>
                             <span class="rank-info">
+                              <a href="{% url 'drama-detail' drama.id %}"
+                                 style="text-decoration: none !important;">
                                 <span class="rank-title">{{ drama.title }}</span>
+                              </a>
+
                             </span>
                             <span class="rank-rating">{{ drama.ranking_score|floatformat:1 }}</span>
                         </li>


### PR DESCRIPTION
- Detail 페이지에 정렬 및 Redirection 추가했으며, 그래프 수정 했습니다.
<img width="981" height="676" alt="스크린샷 2025-10-10 오후 3 57 44" src="https://github.com/user-attachments/assets/4e355ae7-a523-43b5-b480-ec104bc02b68" />

1. 그래프의 회차 클릭 시 해당 회차로 이동
2. 장르 클릭 시 장르 목록 페이지로 이동
3. 그래프 뉴스 수 표시
4. 회차, 시청률, 뉴스 순 정렬 추가

- 드라마 목록 페이지에 redirection 추가했습니다.
<img width="1322" height="587" alt="스크린샷 2025-10-10 오후 3 59 30" src="https://github.com/user-attachments/assets/3ef69f1a-7d8f-4287-9b66-dc0f4c7cd606" />

1. Top 10에서 나오는 드라마 제목 클릭 시 해당 드라마 상세 페이지로 이동
